### PR TITLE
Adding option to ignore underscorizing nested key names by parent key name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,7 @@ By default, the package uses the first case. To use the second case, specify it 
         # ...
         'JSON_UNDERSCOREIZE': {
             'no_underscore_before_number': True,
+            'ignore_child_keys':[]
         },
         # ...
     }
@@ -102,6 +103,22 @@ Alternatively, you can change this behavior on a class level by setting `json_un
         queryset = MyModel.objects.all()
         serializer_class = MySerializer
         parser_classes = (NoUnderscoreBeforeNumberCamelCaseJSONParser,)
+
+
+Underscorize can be set to ignore children of defined keys. Parent key will still be underscoreized
+ignore_child_keys is defined as a list of keys where underscorize will ignore children
+
+example
+.. code-block:: python
+
+    REST_FRAMEWORK = {
+        # ...
+        'JSON_UNDERSCOREIZE': {
+            'no_underscore_before_number': True,
+            'ignore_child_keys':['billingAddress','billing_address']
+        },
+        # ...
+    }
 
 =============
 Running Tests

--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,7 @@ Underscorize can be set to ignore children of defined keys. Parent key will stil
 ignore_child_keys is defined as a list of keys where underscorize will ignore children
 
 example
+
 .. code-block:: python
 
     REST_FRAMEWORK = {

--- a/djangorestframework_camel_case/settings.py
+++ b/djangorestframework_camel_case/settings.py
@@ -8,7 +8,8 @@ USER_SETTINGS = getattr(settings, "JSON_CAMEL_CASE", {})
 DEFAULTS = {
     "RENDERER_CLASS": "rest_framework.renderers.JSONRenderer",
     "PARSER_CLASS": "rest_framework.parsers.JSONParser",
-    "JSON_UNDERSCOREIZE": {"no_underscore_before_number": False},
+    "JSON_UNDERSCOREIZE": {"no_underscore_before_number": False,
+                           "ignore_child_keys": []},
 }
 
 # List of settings that may be in string import notation.

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -64,13 +64,20 @@ def _get_iterable(data):
 
 def underscoreize(data, **options):
     if isinstance(data, dict):
+
+        ignore_keys = options.get("ignore_child_keys") or []
+
         new_dict = {}
         for key, value in _get_iterable(data):
             if isinstance(key, str):
                 new_key = camel_to_underscore(key, **options)
             else:
                 new_key = key
-            new_dict[new_key] = underscoreize(value, **options)
+                
+            if key not in ignore_keys:
+                new_dict[new_key] = underscoreize(value, **options)
+            else:
+                new_dict[new_key] = value
 
         if isinstance(data, QueryDict):
             new_query = QueryDict(mutable=True)

--- a/tests.py
+++ b/tests.py
@@ -212,13 +212,13 @@ class NewTestCase(TestCase):
              "expMonth": 12,
              "expYear": 2020,
              "billingAddress": {
-                        "address1": "Worldpay",
-                        "address2": "1 Milton Road",
+                        "address1": "1 Milton Road",
+                        "address2": "apt #14",
                         "address3": "The Science Park",
                         "postalCode": "CB4 0WE",
-                        "city": "Cambridge",
-                        "state": "Cambs",
-                        "countryCode": "GB"
+                        "city": "Los Angeles",
+                        "state": "LA",
+                        "countryCode": "US"
                     },
             "cardHolderName": "Testy McTester"
         }
@@ -228,13 +228,13 @@ class NewTestCase(TestCase):
             "exp_month": 12,
             "exp_year": 2020,
             "billing_address": {
-                "address1": "Worldpay",
-                "address2": "1 Milton Road",
+                "address1": "1 Milton Road",
+                "address2": "apt #14",
                 "address3": "The Science Park",
                 "postalCode": "CB4 0WE",
-                "city": "Cambridge",
-                "state": "Cambs",
-                "countryCode": "GB"
+                "city": "Los Angeles",
+                "state": "LA",
+                "countryCode": "US"
             },
             "card_holder_name": "Testy McTester"
         }

--- a/tests.py
+++ b/tests.py
@@ -204,3 +204,40 @@ class CamelToUnderscoreQueryDictTestCase(TestCase):
         }
         output_query.update(output)
         self.assertEqual(underscoreize(query_dict), output_query)
+
+class NewTestCase(TestCase):
+    def testConvert(self):
+        input = {
+             "description": "test description",
+             "expMonth": 12,
+             "expYear": 2020,
+             "billingAddress": {
+                        "address1": "Worldpay",
+                        "address2": "1 Milton Road",
+                        "address3": "The Science Park",
+                        "postalCode": "CB4 0WE",
+                        "city": "Cambridge",
+                        "state": "Cambs",
+                        "countryCode": "GB"
+                    },
+            "cardHolderName": "Testy McTester"
+        }
+        print(input)
+        output = {
+            "description": "test description",
+            "exp_month": 12,
+            "exp_year": 2020,
+            "billing_address": {
+                "address1": "Worldpay",
+                "address2": "1 Milton Road",
+                "address3": "The Science Park",
+                "postalCode": "CB4 0WE",
+                "city": "Cambridge",
+                "state": "Cambs",
+                "countryCode": "GB"
+            },
+            "card_holder_name": "Testy McTester"
+        }
+        underscore_input = underscoreize(input, **{"no_underscore_before_number": False,
+                           "ignore_child_keys": ["billingAddress", "billing_address"]})
+        self.assertEqual(underscore_input, output)

--- a/tests.py
+++ b/tests.py
@@ -222,7 +222,7 @@ class NewTestCase(TestCase):
                     },
             "cardHolderName": "Testy McTester"
         }
-        print(input)
+
         output = {
             "description": "test description",
             "exp_month": 12,


### PR DESCRIPTION
add options to ignore underscorizing children of keys defined by config settings